### PR TITLE
feat: cancel activity limit

### DIFF
--- a/nuxt-app/components/activity/ActivityForm.vue
+++ b/nuxt-app/components/activity/ActivityForm.vue
@@ -222,14 +222,22 @@
       emits("reloadData");
     };
 
-    if (isOrganizerPage && activityInfo.value.activityId && status === "update") {
+    if (
+      isOrganizerPage &&
+      activityInfo.value.activityId &&
+      status === "update"
+    ) {
       const { error } = await updateActivity(
         activityInfo.value as ActivityDetail
       );
       if (!error.value) handleSuccess("修改成功");
       return;
     }
-    if (isOrganizerPage && activityInfo.value.activityId && status !== "update") {
+    if (
+      isOrganizerPage &&
+      activityInfo.value.activityId &&
+      status !== "update"
+    ) {
       activityInfo.value.status = status;
       const { error } = await draftActivityToPublished(
         activityInfo.value as ActivityDetail
@@ -245,8 +253,10 @@
       status as "draft" | "published"
     );
     if (!error.value) {
-      if (!isOrganizerPage && status === "published") router.push("/activities");
-      if (!isOrganizerPage && status === "draft") router.push("/member-center/organizer-activities");
+      if (!isOrganizerPage && status === "published")
+        router.push("/activities");
+      if (!isOrganizerPage && status === "draft")
+        router.push("/member-center/organizer-activities");
       handleSuccess(`活動已${status === "draft" ? "儲存" : "發佈"}成功`);
     }
     activityInfoFormRef.value?.resetFields();
@@ -310,12 +320,17 @@
   });
   const isImporting = ref(true);
   onMounted(() => {
-    if (activityEditInfo.value?.activityId || activityEditInfo.value?.status === "copy") {
+    if (
+      activityEditInfo.value?.activityId ||
+      activityEditInfo.value?.status === "copy"
+    ) {
       activityInfo.value = activityEditInfo.value;
       if (activityEditInfo.value?.status === "copy") {
-        activityInfo.value.date = new Date(new Date().setDate(new Date().getDate() + 1))
-  .toISOString()
-  .split("T")[0];
+        activityInfo.value.date = new Date(
+          new Date().setDate(new Date().getDate() + 1)
+        )
+          .toISOString()
+          .split("T")[0];
         activityInfo.value.status = "";
       }
       manuallySetCity(activityEditInfo.value.city);

--- a/nuxt-app/components/activity/ActivityForm.vue
+++ b/nuxt-app/components/activity/ActivityForm.vue
@@ -302,7 +302,7 @@
     const currentMinute = now.getMinutes();
 
     if (activityInfo.value.date === currentDate) {
-      const nextHour = currentMinute > 0 ? currentHour + 1 : currentHour;
+      const nextHour = currentMinute > 0 ? currentHour + 3 : currentHour;
       return `${String(nextHour).padStart(2, "0")}:00`;
     } else {
       return "00:00";

--- a/nuxt-app/layouts/default.vue
+++ b/nuxt-app/layouts/default.vue
@@ -18,8 +18,11 @@
   const authStore = useAuthStore();
   const userStore = useUserStore();
   const userInfo = computed(() => userStore.userInfo);
-  const { loggedIn, clear } = useUserSession();
+  const { loggedIn, clear, fetch } = useUserSession();
   const mobileMenuDialogVisible = ref(false);
+  const defaultAvatar = ref(
+    "https://cube.elemecdn.com/3/7c/3ea6beec64369c2642b92c6726f1epng.png"
+  );
   const loginOrLogout = async () => {
     if (authStore.isAuthenticated) {
       authStore.clearToken();
@@ -61,6 +64,12 @@
     }
     navigateTo("/create-activity");
   };
+  onMounted(async () => {
+    await fetch();
+    if (loggedIn.value) {
+      await userStore.fetchUserInfo();
+    }
+  });
 </script>
 
 <template>
@@ -159,11 +168,10 @@
       </template>
       <template v-if="loggedIn">
         <div class="flex items-center border-b-3 border-neutral-300 py-5 px-3">
-          <img
-            v-if="userInfo?.avatar"
-            :src="userInfo.avatar"
-            alt="User Avatar"
-            class="w-15 h-15 rounded-full mr-6"
+          <el-avatar
+            :size="60"
+            :src="userInfo?.avatar || defaultAvatar"
+            class="mr-6"
           />
           <div class="text-md">
             <p class="text-neutral-400 mb-1">會員</p>
@@ -223,7 +231,7 @@
       <template #footer>
         <ElButton
           size="large"
-          class="flex items-center text-lg w-full border-0 bg-white"
+          class="flex items-center text-lg w-full border-0 bg-white mb-6"
           @click="loginOrLogout"
         >
           <el-icon class="mr-2"><SwitchButton /></el-icon>


### PR DESCRIPTION
- 新增取消報名時之時間限制，設定為 2 小時內無法報名與修改人數
- 修改舉辦活動時，限制舉辦開始時間為 3 小時後
- 修正使用者頭像無檔案時， mobile 選單使用預設頭像